### PR TITLE
Add passage loading text in annotation interface

### DIFF
--- a/quoref.html
+++ b/quoref.html
@@ -139,10 +139,10 @@
                     <div class="passage">
                         <h2>Passage</h2>
                         <div class="passage-0">
+                            <p id="passage-loading"><b>Loading passages...</b></p>
                         </div>
                     </div>
                 </div>
-
                 <div class="right_panel">
                     <h2>Type a question based on the passage below</h2>
                     <div class="question">
@@ -166,9 +166,7 @@
                                         </tr>
                                     </table>
                                 </div>
-
                             </div>
-
                             <div id="rightcolumn">
                                 <h4>AI predicted the answer below <br />(wait for answer to appear below)</h4>
                                 <div class="ai_answer" align="center">
@@ -176,8 +174,6 @@
                                 </div>
                             </div>
                         </div>
-
-
                         <div class="horizontal-scroll-wrapper">
                         </div>
                         <br />
@@ -190,11 +186,8 @@
                         </div>
                     </div>
                 </div>
-
             </div>
-
             <div class="bottom_panel">
-
                 <button id="ready_submit" type="button" class="btn" onclick="final_submit()" onmouseover="check_question_count();">
                     Ready to Submit HIT
                 </button>
@@ -209,7 +202,6 @@
 
             </div>
         </div>
-       
         <br />
         <br />
         <div id="comment">
@@ -229,7 +221,6 @@
         </div>
 
     </form>
-        <script language='Javascript'>turkSetAssignmentID();</script>
-    </body>
-
-    </html>
+    <script language='Javascript'>turkSetAssignmentID();</script>
+</body>
+</html>


### PR DESCRIPTION
This branches off of #1 , i'll rebase after #1 is merged and the diff should be easier to look at after that.

currently working from a place without great internet, and it takes awhile for the passages to get loaded. I was a bit confused, since the annotation interface just looks blank while things are loading (i thought it was broken at first, but it just needed a few minutes to load). I added a loading message that is automatically overwritten when the passages are written to the front-end.